### PR TITLE
[201911] [neighsyncd] backport increase neighsyncd timeout (#2209)

### DIFF
--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -14,7 +14,7 @@
  * service to finish, should be longer than the restore_neighbors timeout value (110)
  * This should not happen, if happens, system is in a unknown state, we should exit.
  */
-#define RESTORE_NEIGH_WAIT_TIME_OUT 120
+#define RESTORE_NEIGH_WAIT_TIME_OUT 180
 
 namespace swss {
 


### PR DESCRIPTION
- What I did
Increased the neighsyncd timeout.

- Why I did it
Restore_neigh takes a bit more time to start thus it could be that the neighsyncd timeout is not enough to wait for restore_neighbors

- How I verified it
py.test platform_tests/test_advanced_reboot.py::test_warm_reboot_sad[sad_lag_member] --inventory="../ansible/inventory,../ansible/veos" --host-pattern arc-switch1004 --module-path ../ansible/library/ --testbed arc-switch1004-t0-56 --testbed_file ../ansible/testbed.csv --allow_recover --log-cli-level info --skip_sanity

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
