### PR TITLE
[portmgr] Fixed the Orchagent crash due to late arrival of notif

### DIFF
--- a/cfgmgr/portmgr.h
+++ b/cfgmgr/portmgr.h
@@ -30,6 +30,7 @@ private:
 
     void doTask(Consumer &consumer);
     bool writeConfigToAppDb(const std::string &alias, const std::string &field, const std::string &value);
+    bool writeConfigToAppDb(const std::string &alias, const std::vector<FieldValueTuple>& field_values);
     bool setPortMtu(const std::string &alias, const std::string &mtu);
     bool setPortAdminStatus(const std::string &alias, const bool up);
     bool isPortStateOk(const std::string &alias);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

After the recent incremental config update changes, portmgrd will be writing to the APPL_DB PORT_TABLE (Except during startup where portyncd writes to the APP_DB). 

This can lead to a problem during breakout and might cause orchagent to crash i.e. portmgrd currently doesn't write to the APPL_DB at once but in steps. 

In some cases (high probability, not always), orchagent decides to act on the notifcations immediately and since speed is not set, it tries to create_port with speed 0 and the orchagent crashes 


```
2022-08-25.10:45:56.708466|PORT_TABLE:Ethernet232|DEL
2022-08-25.10:45:57.669534|PORT_TABLE:Ethernet232|SET|alias:etp30a|index:30
2022-08-25.10:45:57.670749|PORT_TABLE:Ethernet232|SET|lanes:232,233
```

```
Aug 25 13:45:57.838085 r-leopard-41 ERR syncd#SDK: [SAI_PORT.ERR] mlnx_sai_port.c[2809]- mlnx_port_speeds_merge: Port [Speed[0x00000000] - Interface_Type[0x0000ffff]] configuration is invalid.
Aug 25 13:45:57.838085 r-leopard-41 ERR syncd#SDK: [SAI_PORT.ERR] mlnx_sai_port.c[3086]- mlnx_port_update_speed: Failed to merge speeds, interface types and auto_neg.
Aug 25 13:45:57.838085 r-leopard-41 ERR syncd#SDK: [SAI_PORT.ERR] mlnx_sai_port.c[9666]- mlnx_create_port: Failed to update speed.
Aug 25 13:45:57.838674 r-leopard-41 ERR swss#orchagent: :- create: create status: SAI_STATUS_NOT_SUPPORTED
Aug 25 13:45:57.838674 r-leopard-41 ERR swss#orchagent: :- addPort: Failed to create port with the speed 0, rv:-2
Aug 25 13:45:57.838693 r-leopard-41 ERR swss#orchagent: :- handleSaiCreateStatus: Encountered failure in create operation, exiting orchagent, SAI API: SAI_API_PORT, status: SAI_STATUS_NOT_SUPPORTED
```

```
2022-08-25.10:45:57.671548|c|SAI_OBJECT_TYPE_PORT:oid:0x1000000000adb|SAI_PORT_ATTR_SPEED=0|SAI_PORT_ATTR_HW_LANE_LIST=2:232,233
2022-08-25.10:45:57.838523|E|SAI_STATUS_NOT_SUPPORTED
```


**How I verified it**

1) Existing Unit Tests
2) Tested on the switch:

Before the fix:

root@r-panther-23:/home/admin# config interface breakout Ethernet72 2x50G[25G,10G] -y -f

```
2022-08-26.03:57:26.451022|INTF_TABLE:Ethernet72|DEL
2022-08-26.03:57:27.208461|PORT_TABLE:Ethernet72|SET|alias:etp19a|index:19
2022-08-26.03:57:27.211031|PORT_TABLE:Ethernet72|SET|lanes:72,73|speed:50000
2022-08-26.03:57:27.852567|PORT_TABLE:Ethernet72|SET|mtu:9100|admin_status:down
2022-08-26.03:57:28.245470|PORT_TABLE:Ethernet72|SET|mtu:9100
2022-08-26.03:57:28.250334|PORT_TABLE:Ethernet72|SET|admin_status:down
```

After the fix:
```
2022-08-26.04:06:22.060385|PORT_TABLE:Ethernet72|SET|alias:etp19a|index:19|lanes:72,73|speed:50000|mtu:9100
2022-08-26.04:06:22.865474|PORT_TABLE:Ethernet72|SET|admin_status:down
```

```
Aug 26 04:06:22.051149 sonic NOTICE swss#portmgrd: :- writeConfigToAppDb: Configure Ethernet72, alias:etp19a index:19 lanes:72,73 speed:50000
```

**Details if related**
