### PR TITLE
[202211] [sflowmgrd] Infer sampling rate dynamically based on oper speed

### DIFF
--- a/cfgmgr/sflowmgr.cpp
+++ b/cfgmgr/sflowmgr.cpp
@@ -10,27 +10,40 @@
 using namespace std;
 using namespace swss;
 
-map<string,string> sflowSpeedRateInitMap =
-{
-    {SFLOW_SAMPLE_RATE_KEY_400G, SFLOW_SAMPLE_RATE_VALUE_400G},
-    {SFLOW_SAMPLE_RATE_KEY_200G, SFLOW_SAMPLE_RATE_VALUE_200G},
-    {SFLOW_SAMPLE_RATE_KEY_100G, SFLOW_SAMPLE_RATE_VALUE_100G},
-    {SFLOW_SAMPLE_RATE_KEY_50G, SFLOW_SAMPLE_RATE_VALUE_50G},
-    {SFLOW_SAMPLE_RATE_KEY_40G, SFLOW_SAMPLE_RATE_VALUE_40G},
-    {SFLOW_SAMPLE_RATE_KEY_25G, SFLOW_SAMPLE_RATE_VALUE_25G},
-    {SFLOW_SAMPLE_RATE_KEY_10G, SFLOW_SAMPLE_RATE_VALUE_10G},
-    {SFLOW_SAMPLE_RATE_KEY_1G, SFLOW_SAMPLE_RATE_VALUE_1G}
-};
-
-SflowMgr::SflowMgr(DBConnector *cfgDb, DBConnector *appDb, const vector<string> &tableNames) :
-        Orch(cfgDb, tableNames),
-        m_cfgSflowTable(cfgDb, CFG_SFLOW_TABLE_NAME),
-        m_cfgSflowSessionTable(cfgDb, CFG_SFLOW_SESSION_TABLE_NAME),
+SflowMgr::SflowMgr(DBConnector *appDb, const std::vector<TableConnector>& tableNames) :
+        Orch(tableNames),
         m_appSflowTable(appDb, APP_SFLOW_TABLE_NAME),
         m_appSflowSessionTable(appDb, APP_SFLOW_SESSION_TABLE_NAME)
 {
     m_intfAllConf = true;
     m_gEnable = false;
+}
+
+void SflowMgr::readPortConfig()
+{
+    auto consumer_it = m_consumerMap.find(CFG_PORT_TABLE_NAME);
+    if (consumer_it != m_consumerMap.end())
+    {
+        consumer_it->second->drain();
+        SWSS_LOG_NOTICE("Port Configuration Read..");
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Consumer object for PORT_TABLE not found");
+    }
+}
+
+bool SflowMgr::isPortEnabled(const std::string& alias)
+{
+    /* Checks if the sflow is enabled on the port */
+    auto it = m_sflowPortConfMap.find(alias);
+    if (it == m_sflowPortConfMap.end())
+    {
+        return false;
+    }
+    bool local_admin = it->second.local_admin_cfg;
+    bool status = it->second.admin == "up" ? true : false;
+    return m_gEnable && (m_intfAllConf || (local_admin && status));
 }
 
 void SflowMgr::sflowHandleService(bool enable)
@@ -69,7 +82,6 @@ void SflowMgr::sflowUpdatePortInfo(Consumer &consumer)
     while (it != consumer.m_toSync.end())
     {
         KeyOpFieldsValuesTuple t = it->second;
-
         string key = kfvKey(t);
         string op = kfvOp(t);
         auto values = kfvFieldsValues(t);
@@ -85,14 +97,15 @@ void SflowMgr::sflowUpdatePortInfo(Consumer &consumer)
                 new_port = true;
                 port_info.local_rate_cfg = false;
                 port_info.local_admin_cfg = false;
-                port_info.speed = SFLOW_ERROR_SPEED_STR;
+                port_info.speed = ERROR_SPEED;
+                port_info.oper_speed = NA_SPEED;
                 port_info.rate = "";
                 port_info.admin = "";
                 m_sflowPortConfMap[key] = port_info;
             }
 
-            bool speed_change = false;
-            string new_speed = SFLOW_ERROR_SPEED_STR;
+            bool rate_update = false;
+            string new_speed = ERROR_SPEED;
             for (auto i : values)
             {
                 if (fvField(i) == "speed")
@@ -103,16 +116,20 @@ void SflowMgr::sflowUpdatePortInfo(Consumer &consumer)
             if (m_sflowPortConfMap[key].speed != new_speed)
             {
                 m_sflowPortConfMap[key].speed = new_speed;
-                speed_change = true;
+                /* if oper_speed is set, no need to write to APP_DB */
+                if (m_sflowPortConfMap[key].oper_speed == NA_SPEED)
+                {
+                    rate_update = true;
+                }
             }
 
-            if (m_gEnable && m_intfAllConf)
+            if (isPortEnabled(key))
             {
-                // If the Local rate Conf is already present, dont't override it even though the speed is changed
-                if (new_port || (speed_change && !m_sflowPortConfMap[key].local_rate_cfg))
+                // If the Local rate conf is already present, dont't override it even though the speed is changed
+                if (new_port || (rate_update && !m_sflowPortConfMap[key].local_rate_cfg))
                 {
                     vector<FieldValueTuple> fvs;
-                    sflowGetGlobalInfo(fvs, m_sflowPortConfMap[key].speed);
+                    sflowGetGlobalInfo(fvs, key);
                     m_appSflowSessionTable.set(key, fvs);
                 }
             }
@@ -136,6 +153,60 @@ void SflowMgr::sflowUpdatePortInfo(Consumer &consumer)
     }
 }
 
+void SflowMgr::sflowProcessOperSpeed(Consumer &consumer)
+{
+    auto it = consumer.m_toSync.begin();
+
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+        string alias = kfvKey(t);
+        string op = kfvOp(t);
+        auto values = kfvFieldsValues(t);
+        string oper_speed = "";
+        bool rate_update = false;
+
+        for (auto i : values)
+        {
+            if (fvField(i) == "speed")
+            {
+                oper_speed = fvValue(i);
+            }
+        }
+
+        if (m_sflowPortConfMap.find(alias) != m_sflowPortConfMap.end() && op == SET_COMMAND)
+        {
+            SWSS_LOG_DEBUG("STATE_DB update: iface: %s, oper_speed: %s, cfg_speed: %s, new_speed: %s",
+                            alias.c_str(), m_sflowPortConfMap[alias].oper_speed.c_str(),
+                            m_sflowPortConfMap[alias].speed.c_str(),
+                            oper_speed.c_str());
+            /* oper_speed is updated by orchagent if the vendor supports and oper status is up */
+            if (m_sflowPortConfMap[alias].oper_speed != oper_speed && !oper_speed.empty())
+            {
+                rate_update = true;
+                if (oper_speed == m_sflowPortConfMap[alias].speed && m_sflowPortConfMap[alias].oper_speed == NA_SPEED)
+                {
+                    /* if oper_speed is equal to cfg_speed, avoid the write to APP_DB
+                       Can happen if auto-neg is not set */
+                    rate_update = false;
+                }
+                m_sflowPortConfMap[alias].oper_speed = oper_speed;
+            }
+
+            if (isPortEnabled(alias) && rate_update && !m_sflowPortConfMap[alias].local_rate_cfg)
+            {
+                auto rate = findSamplingRate(alias);
+                FieldValueTuple fv("sample_rate", rate);
+                vector<FieldValueTuple> fvs = {fv};
+                m_appSflowSessionTable.set(alias, fvs);
+                SWSS_LOG_NOTICE("Default sampling rate for %s updated to %s", alias.c_str(), rate.c_str());
+            }
+        }
+        /* Do nothing for DEL as the SflowPortConfMap will already be cleared by the DEL from CONFIG_DB */ 
+        it = consumer.m_toSync.erase(it);
+    }
+}
+
 void SflowMgr::sflowHandleSessionAll(bool enable)
 {
     for (auto it: m_sflowPortConfMap)
@@ -154,7 +225,7 @@ void SflowMgr::sflowHandleSessionAll(bool enable)
             }
             else
             {
-                sflowGetGlobalInfo(fvs, it.second.speed);
+                sflowGetGlobalInfo(fvs, it.first);
             }
             m_appSflowSessionTable.set(it.first, fvs);
         }
@@ -185,21 +256,12 @@ void SflowMgr::sflowHandleSessionLocal(bool enable)
     }
 }
 
-void SflowMgr::sflowGetGlobalInfo(vector<FieldValueTuple> &fvs, string speed)
+void SflowMgr::sflowGetGlobalInfo(vector<FieldValueTuple> &fvs, const string& alias)
 {
-    string rate;
     FieldValueTuple fv1("admin_state", "up");
     fvs.push_back(fv1);
 
-    if (speed != SFLOW_ERROR_SPEED_STR && sflowSpeedRateInitMap.find(speed) != sflowSpeedRateInitMap.end())
-    {
-        rate = sflowSpeedRateInitMap[speed];
-    }
-    else
-    {
-        rate = SFLOW_ERROR_SPEED_STR;
-    }
-    FieldValueTuple fv2("sample_rate",rate);
+    FieldValueTuple fv2("sample_rate", findSamplingRate(alias));
     fvs.push_back(fv2);
 }
 
@@ -254,17 +316,7 @@ void SflowMgr::sflowCheckAndFillValues(string alias, vector<FieldValueTuple> &va
         if (m_sflowPortConfMap[alias].rate == "" ||
             m_sflowPortConfMap[alias].local_rate_cfg)
         {
-            string speed = m_sflowPortConfMap[alias].speed;
-
-            if (speed != SFLOW_ERROR_SPEED_STR && sflowSpeedRateInitMap.find(speed) != sflowSpeedRateInitMap.end())
-            {
-                rate = sflowSpeedRateInitMap[speed];
-            }
-            else
-            {
-                rate = SFLOW_ERROR_SPEED_STR;
-            }
-            m_sflowPortConfMap[alias].rate = rate;
+            m_sflowPortConfMap[alias].rate = findSamplingRate(alias);
         }
         m_sflowPortConfMap[alias].local_rate_cfg = false;
         FieldValueTuple fv("sample_rate", m_sflowPortConfMap[alias].rate);
@@ -284,6 +336,24 @@ void SflowMgr::sflowCheckAndFillValues(string alias, vector<FieldValueTuple> &va
     }
 }
 
+string SflowMgr::findSamplingRate(const string& alias)
+{
+    /* Default sampling rate is equal to the oper_speed in Gbps or error 
+        if oper_speed is not found, use the configured speed */
+    if (m_sflowPortConfMap.find(alias) == m_sflowPortConfMap.end())
+    {
+        SWSS_LOG_ERROR("%s not found in port configuration map", alias.c_str());
+        return ERROR_SPEED;
+    }
+    string oper_speed = m_sflowPortConfMap[alias].oper_speed;
+    string cfg_speed = m_sflowPortConfMap[alias].speed;
+    if (!oper_speed.empty() && oper_speed != NA_SPEED)
+    {
+        return oper_speed;
+    }
+    return cfg_speed;
+}
+
 void SflowMgr::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -293,6 +363,11 @@ void SflowMgr::doTask(Consumer &consumer)
     if (table == CFG_PORT_TABLE_NAME)
     {
         sflowUpdatePortInfo(consumer);
+        return;
+    }
+    else if (table == STATE_PORT_TABLE_NAME)
+    {
+        sflowProcessOperSpeed(consumer);
         return;
     }
 
@@ -411,7 +486,7 @@ void SflowMgr::doTask(Consumer &consumer)
                     if (m_intfAllConf)
                     {
                         vector<FieldValueTuple> fvs;
-                        sflowGetGlobalInfo(fvs, m_sflowPortConfMap[key].speed);
+                        sflowGetGlobalInfo(fvs, key);
                         m_appSflowSessionTable.set(key,fvs);
                     }
                 }

--- a/cfgmgr/sflowmgr.cpp
+++ b/cfgmgr/sflowmgr.cpp
@@ -338,7 +338,7 @@ void SflowMgr::sflowCheckAndFillValues(string alias, vector<FieldValueTuple> &va
 
 string SflowMgr::findSamplingRate(const string& alias)
 {
-    /* Default sampling rate is equal to the oper_speed in Gbps or error 
+    /* Default sampling rate is equal to the oper_speed, if present. 
         if oper_speed is not found, use the configured speed */
     if (m_sflowPortConfMap.find(alias) == m_sflowPortConfMap.end())
     {

--- a/cfgmgr/sflowmgr.h
+++ b/cfgmgr/sflowmgr.h
@@ -10,31 +10,15 @@
 
 namespace swss {
 
-#define SFLOW_SAMPLE_RATE_KEY_400G "400000"
-#define SFLOW_SAMPLE_RATE_KEY_200G "200000"
-#define SFLOW_SAMPLE_RATE_KEY_100G "100000"
-#define SFLOW_SAMPLE_RATE_KEY_50G  "50000"
-#define SFLOW_SAMPLE_RATE_KEY_40G  "40000"
-#define SFLOW_SAMPLE_RATE_KEY_25G  "25000"
-#define SFLOW_SAMPLE_RATE_KEY_10G  "10000"
-#define SFLOW_SAMPLE_RATE_KEY_1G   "1000"
-
-#define SFLOW_SAMPLE_RATE_VALUE_400G "400000"
-#define SFLOW_SAMPLE_RATE_VALUE_200G "200000"
-#define SFLOW_SAMPLE_RATE_VALUE_100G "100000"
-#define SFLOW_SAMPLE_RATE_VALUE_50G  "50000"
-#define SFLOW_SAMPLE_RATE_VALUE_40G  "40000"
-#define SFLOW_SAMPLE_RATE_VALUE_25G  "25000"
-#define SFLOW_SAMPLE_RATE_VALUE_10G  "10000"
-#define SFLOW_SAMPLE_RATE_VALUE_1G   "1000"
-
-#define SFLOW_ERROR_SPEED_STR "error"
+#define ERROR_SPEED "error"
+#define NA_SPEED "N/A"
 
 struct SflowPortInfo
 {
     bool        local_rate_cfg;
     bool        local_admin_cfg;
     std::string speed;
+    std::string oper_speed;
     std::string rate;
     std::string admin;
 };
@@ -45,26 +29,28 @@ typedef std::map<std::string, SflowPortInfo> SflowPortConfMap;
 class SflowMgr : public Orch
 {
 public:
-    SflowMgr(DBConnector *cfgDb, DBConnector *appDb, const std::vector<std::string> &tableNames);
+    SflowMgr(DBConnector *appDb, const std::vector<TableConnector>& tableNames);
+    void readPortConfig();
 
     using Orch::doTask;
 private:
-    Table                  m_cfgSflowTable;
-    Table                  m_cfgSflowSessionTable;
     ProducerStateTable     m_appSflowTable;
     ProducerStateTable     m_appSflowSessionTable;
-    SflowPortConfMap  m_sflowPortConfMap;
+    SflowPortConfMap       m_sflowPortConfMap;
     bool                   m_intfAllConf;
     bool                   m_gEnable;
 
     void doTask(Consumer &consumer);
     void sflowHandleService(bool enable);
     void sflowUpdatePortInfo(Consumer &consumer);
+    void sflowProcessOperSpeed(Consumer &consumer);
     void sflowHandleSessionAll(bool enable);
     void sflowHandleSessionLocal(bool enable);
     void sflowCheckAndFillValues(std::string alias, std::vector<FieldValueTuple> &values, std::vector<FieldValueTuple> &fvs);
     void sflowGetPortInfo(std::vector<FieldValueTuple> &fvs, SflowPortInfo &local_info);
-    void sflowGetGlobalInfo(std::vector<FieldValueTuple> &fvs, std::string speed);
+    void sflowGetGlobalInfo(std::vector<FieldValueTuple> &fvs, const std::string& alias);
+    bool isPortEnabled(const std::string& alias);
+    std::string findSamplingRate(const std::string& speed);
 };
 
 }

--- a/cfgmgr/sflowmgrd.cpp
+++ b/cfgmgr/sflowmgrd.cpp
@@ -61,8 +61,8 @@ int main(int argc, char **argv)
         };
 
         SflowMgr sflowmgr(&appDb, sflow_tables);
-        /* During process startup, the ordering of cfg_db followed by state_db notifications cannot be guaranteed 
-           and so handle the cfg notifs manually */
+        /* During process startup, the ordering of config_db followed by state_db notifications cannot be guaranteed 
+           and so handle the cfg events manually first */
         sflowmgr.readPortConfig();
 
         vector<Orch *> orchList = {&sflowmgr};

--- a/cfgmgr/sflowmgrd.cpp
+++ b/cfgmgr/sflowmgrd.cpp
@@ -44,21 +44,31 @@ int main(int argc, char **argv)
 
     try
     {
-        vector<string> cfg_sflow_tables = {
-            CFG_SFLOW_TABLE_NAME,
-            CFG_SFLOW_SESSION_TABLE_NAME,
-            CFG_PORT_TABLE_NAME
-        };
-
         DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
+        DBConnector stateDb("STATE_DB", 0);
 
-        SflowMgr sflowmgr(&cfgDb, &appDb, cfg_sflow_tables);
+        TableConnector conf_port_table(&cfgDb, CFG_PORT_TABLE_NAME);
+        TableConnector state_port_table(&stateDb, STATE_PORT_TABLE_NAME);
+        TableConnector conf_sflow_table(&cfgDb, CFG_SFLOW_TABLE_NAME);
+        TableConnector conf_sflow_session_table(&cfgDb, CFG_SFLOW_SESSION_TABLE_NAME);
 
-        vector<Orch *> cfgOrchList = {&sflowmgr};
+        vector<TableConnector> sflow_tables = {
+            conf_port_table,
+            state_port_table,
+            conf_sflow_table,
+            conf_sflow_session_table
+        };
+
+        SflowMgr sflowmgr(&appDb, sflow_tables);
+        /* During process startup, the ordering of cfg_db followed by state_db notifications cannot be guaranteed 
+           and so handle the cfg notifs manually */
+        sflowmgr.readPortConfig();
+
+        vector<Orch *> orchList = {&sflowmgr};
 
         swss::Select s;
-        for (Orch *o : cfgOrchList)
+        for (Orch *o : orchList)
         {
             s.addSelectables(o->getSelectables());
         }

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -45,6 +45,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 mock_redisreply.cpp \
                 bulker_ut.cpp \
                 portmgr_ut.cpp \
+                sflowmgrd_ut.cpp \
                 fake_response_publisher.cpp \
                 swssnet_ut.cpp \
                 flowcounterrouteorch_ut.cpp \
@@ -108,6 +109,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/srv6orch.cpp \
                 $(top_srcdir)/orchagent/nvgreorch.cpp \
                 $(top_srcdir)/cfgmgr/portmgr.cpp \
+                $(top_srcdir)/cfgmgr/sflowmgr.cpp \
                 $(top_srcdir)/cfgmgr/buffermgrdyn.cpp \
                 $(top_srcdir)/warmrestart/warmRestartAssist.cpp
 

--- a/tests/mock_tests/sflowmgrd_ut.cpp
+++ b/tests/mock_tests/sflowmgrd_ut.cpp
@@ -1,0 +1,240 @@
+#include "gtest/gtest.h"
+#include "mock_table.h"
+#include "redisutility.h"
+#include "sflowmgr.h"
+
+namespace sflowmgr_ut
+{
+    using namespace swss;
+    using namespace std;
+
+    struct SflowMgrTest : public ::testing::Test
+    {
+        shared_ptr<swss::DBConnector> m_app_db;
+        shared_ptr<swss::DBConnector> m_config_db;
+        shared_ptr<swss::DBConnector> m_state_db;
+        shared_ptr<SflowMgr> m_sflowMgr;
+        SflowMgrTest()
+        {
+            m_app_db = make_shared<swss::DBConnector>(
+                "APPL_DB", 0);
+            m_config_db = make_shared<swss::DBConnector>(
+                "CONFIG_DB", 0);
+            m_state_db = make_shared<swss::DBConnector>(
+                "STATE_DB", 0);
+        }
+
+        virtual void SetUp() override
+        {
+            ::testing_db::reset();
+            TableConnector conf_port_table(m_config_db.get(), CFG_PORT_TABLE_NAME);
+            TableConnector state_port_table(m_state_db.get(), STATE_PORT_TABLE_NAME);
+            TableConnector conf_sflow_table(m_config_db.get(), CFG_SFLOW_TABLE_NAME);
+            TableConnector conf_sflow_session_table(m_config_db.get(), CFG_SFLOW_SESSION_TABLE_NAME);
+
+            vector<TableConnector> sflow_tables = {
+                conf_port_table,
+                state_port_table,
+                conf_sflow_table,
+                conf_sflow_session_table
+            };
+            m_sflowMgr.reset(new SflowMgr(m_app_db.get(), sflow_tables));
+            enableSflow();
+        }
+
+        void enableSflow()
+        {
+            Table cfg_sflow(m_config_db.get(), CFG_SFLOW_TABLE_NAME);
+            cfg_sflow.set("global", {
+                {"admin_state", "up"}
+            });
+            m_sflowMgr->addExistingData(&cfg_sflow);
+            m_sflowMgr->doTask();
+        }
+
+        void cfgSflowSession(string alias, bool status, string sample_rate)
+        {
+            Table cfg_sflow_table(m_config_db.get(), CFG_SFLOW_SESSION_TABLE_NAME);
+            vector<FieldValueTuple> values;
+            values.emplace_back("admin_state", status ? "up" : "down");
+            if (!sample_rate.empty())
+            {
+                values.emplace_back("sample_rate", sample_rate);
+            }
+            cfg_sflow_table.set(alias, values);
+            m_sflowMgr->addExistingData(&cfg_sflow_table);
+            m_sflowMgr->doTask();
+        }
+
+        void cfgSflowSessionAll(bool status)
+        {
+            Table cfg_sflow_table(m_config_db.get(), CFG_SFLOW_SESSION_TABLE_NAME);
+            cfg_sflow_table.set("all", {
+                {"admin_state", status ? "up" : "down"},
+            });
+            m_sflowMgr->addExistingData(&cfg_sflow_table);
+            m_sflowMgr->doTask();
+        }
+
+        void cfgPortSpeed(string alias, string speed)
+        {
+            Table cfg_port_table(m_config_db.get(), CFG_PORT_TABLE_NAME);
+            cfg_port_table.set(alias, {
+                {"speed", speed}
+            });
+            m_sflowMgr->addExistingData(&cfg_port_table);
+            m_sflowMgr->doTask();
+        }
+
+        void statePortSpeed(string alias, string speed)
+        {
+            Table state_port_table(m_config_db.get(), STATE_PORT_TABLE_NAME);
+            state_port_table.set(alias, {
+                {"speed", speed}
+            });
+            m_sflowMgr->addExistingData(&state_port_table);
+            m_sflowMgr->doTask();
+        }
+
+        string getSflowSampleRate(string alias)
+        {
+            Table appl_sflow_table(m_app_db.get(), APP_SFLOW_SESSION_TABLE_NAME);
+            std::vector<FieldValueTuple> values;
+            appl_sflow_table.get("Ethernet0", values);
+            auto value_rate = swss::fvsGetValue(values, "sample_rate", true);
+            if (value_rate)
+            {
+                string ret = value_rate.get();
+                return ret;
+            }
+            return "";
+        }
+
+        string getSflowAdminStatus(string alias)
+        {
+            Table appl_sflow_table(m_app_db.get(), APP_SFLOW_SESSION_TABLE_NAME);
+            std::vector<FieldValueTuple> values;
+            appl_sflow_table.get("Ethernet0", values);
+            auto value_rate = swss::fvsGetValue(values, "admin_state", true);
+            if (value_rate)
+            {
+                string ret = value_rate.get();
+                return ret;
+            }
+            return "down";
+        }
+    };
+
+    TEST_F(SflowMgrTest, test_RateConfiguration)
+    {
+        cfgPortSpeed("Ethernet0", "100000");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "100000");
+
+        /* Scenario: Operational Speed Changes to 25000 */
+        statePortSpeed("Ethernet0", "25000");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "25000");
+    }
+
+    TEST_F(SflowMgrTest, test_RateConfigurationCfgSpeed)
+    {
+        /* Configure the Speed to 100G */
+        cfgPortSpeed("Ethernet0", "100000");
+
+        /* Scenario: Operational Speed Changes to 100G with autoneg */
+        statePortSpeed("Ethernet0", "100000");
+
+        /* User changes the config speed to 10G */
+        cfgPortSpeed("Ethernet0", "10000");
+
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "100000");
+
+        /* Scenario: Operational Speed Changes to 10G, with autoneg */
+        statePortSpeed("Ethernet0", "10000");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "10000");
+
+        /* Configured speed is updated by user */
+        cfgPortSpeed("Ethernet0", "200000");
+
+        /* Sampling Rate will not be updated */
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "10000");
+    }
+
+    TEST_F(SflowMgrTest, test_OnlyStateDbNotif)
+    {
+        statePortSpeed("Ethernet0", "100000");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "");
+    }
+
+    TEST_F(SflowMgrTest, test_LocalRateConfiguration)
+    {
+        cfgPortSpeed("Ethernet0", "100000");
+        cfgSflowSession("Ethernet0", true, "12345");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "12345");
+    }
+
+    TEST_F(SflowMgrTest, test_LocalRateConfWithOperSpeed)
+    {
+        cfgPortSpeed("Ethernet0", "100000");
+
+        /* Scenario: Operational Speed Changes to 25000 */
+        statePortSpeed("Ethernet0", "25000");
+
+        /* Set per interface sampling rate*/
+        cfgSflowSession("Ethernet0", true, "12345");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "12345");
+
+        /* Operational Speed Changes again to 50000 */
+        statePortSpeed("Ethernet0", "50000");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "12345");
+    }
+
+    TEST_F(SflowMgrTest, test_newSpeed)
+    {
+        cfgPortSpeed("Ethernet0", "800000");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "800000");
+    }
+
+    TEST_F(SflowMgrTest, test_CfgSpeedAdminCfg)
+    {
+        cfgPortSpeed("Ethernet0", "100000");
+        cfgSflowSessionAll(false); /* Disable sflow on all interfaces*/
+        ASSERT_TRUE(getSflowAdminStatus("Ethernet0") == "down");
+        cfgSflowSession("Ethernet0", true, ""); /* Set local admin up with no rate */
+        ASSERT_TRUE(getSflowAdminStatus("Ethernet0") == "up");
+
+        /* Sampling rate should adhere to config speed*/
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "100000");
+
+        cfgPortSpeed("Ethernet0", "25000"); /* Change cfg speed */
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "25000");
+    }
+
+    TEST_F(SflowMgrTest, test_OperSpeedAdminCfg)
+    {
+        cfgPortSpeed("Ethernet0", "100000");
+        cfgSflowSessionAll(false); /* Disable sflow on all interfaces*/
+        cfgSflowSession("Ethernet0", true, ""); /* Set local admin up with no rate */
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "100000");
+        ASSERT_TRUE(getSflowAdminStatus("Ethernet0") == "up");
+
+        statePortSpeed("Ethernet0", "50000");
+        /* Sampling rate should adhere to oper speed*/
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "50000");
+        ASSERT_TRUE(getSflowAdminStatus("Ethernet0") == "up");
+
+        /* Change cfg speed */
+        cfgPortSpeed("Ethernet0", "25000");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "50000");
+
+        statePortSpeed("Ethernet0", "1000");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "1000");
+
+        cfgSflowSession("Ethernet0", true, "12345"); /* Set local sampling rate */
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "12345");
+        ASSERT_TRUE(getSflowAdminStatus("Ethernet0") == "up");
+
+        /* Change oper speed now */
+        statePortSpeed("Ethernet0", "12345");
+        ASSERT_TRUE(getSflowSampleRate("Ethernet0") == "12345");
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

1) Remove sflowSpeedRateInitMap and infer the default sampling rate based on speed on the interface.
2) Make the rate inference based on oper_speed.

**Why I did it**

1) With Static Map, adding a new speed would require updating the code.
2) auotneg might change the operational speed on the port but the default sampling rate is not updated

**How I verified it**

1) UT's:
```
vkarri@3e8d51f2fa45:/sonic/src/sonic-swss/tests/mock_tests$ ./tests --gtest_filter="*SflowMgrTest*"
Running main() from /build/googletest-YnT0O3/googletest-1.10.0.20201025/googletest/src/gtest_main.cc
Note: Google Test filter = *SflowMgrTest*
[==========] Running 8 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 8 tests from SflowMgrTest
[ RUN      ] SflowMgrTest.test_RateConfiguration
[       OK ] SflowMgrTest.test_RateConfiguration (0 ms)
[ RUN      ] SflowMgrTest.test_RateConfigurationCfgSpeed
[       OK ] SflowMgrTest.test_RateConfigurationCfgSpeed (1 ms)
[ RUN      ] SflowMgrTest.test_OnlyStateDbNotif
[       OK ] SflowMgrTest.test_OnlyStateDbNotif (0 ms)
[ RUN      ] SflowMgrTest.test_LocalRateConfiguration
[       OK ] SflowMgrTest.test_LocalRateConfiguration (0 ms)
[ RUN      ] SflowMgrTest.test_LocalRateConfWithOperSpeed
[       OK ] SflowMgrTest.test_LocalRateConfWithOperSpeed (0 ms)
[ RUN      ] SflowMgrTest.test_newSpeed
[       OK ] SflowMgrTest.test_newSpeed (0 ms)
[ RUN      ] SflowMgrTest.test_CfgSpeedAdminCfg
[       OK ] SflowMgrTest.test_CfgSpeedAdminCfg (0 ms)
[ RUN      ] SflowMgrTest.test_OperSpeedAdminCfg
[       OK ] SflowMgrTest.test_OperSpeedAdminCfg (1 ms)
[----------] 8 tests from SflowMgrTest (2 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 8 tests.

```
2) Run manual tests on a DUT

**Test normal speed change without autoneg**

```
root@dut:/home/admin# show sflow interface | grep Ethernet220
| Ethernet220 | up            |          100000 |

root@dut:/home/admin# config interface speed Ethernet220 50000
root@dut:/home/admin# show sflow interface | grep Ethernet220
| Ethernet220 | up            |           50000 |

root@dut:/home/admin# config interface speed Ethernet220 25000
root@dut:/home/admin# show sflow interface | grep Ethernet220
| Ethernet220 | up            |           25000 |
```

**Test rate change with autoneg**

Ethernet205 <-> Ethernet209 Back to back connected

```
root@dut:/# show interfaces status 
Ethernet205              205      25G   9100    N/A   etp52b  routed      up       up    QSFP28 or later         N/A
Ethernet209              209      25G   9100    N/A   etp53b  routed      up       up    QSFP28 or later         N/A

<Check sampling rate before >
root@dut:/# show sflow interface
| Ethernet205 | up            |           25000 |
| Ethernet209 | up            |           25000 |

<Enable autoneg on 209>
root@dut:/# config interface autoneg Ethernet209 enabled
<Change speed on the peer port>
root@dut:/# config interface speed Ethernet205 10000

<Speed on 209 is updated because of autoneg>
root@dut:/# show interfaces status 
Ethernet205              205      10G   9100    N/A   etp52b  routed      up       up   QSFP28 or later         N/A
Ethernet209              209      10G   9100    N/A   etp53b  routed      up       up   QSFP28 or later         N/A

<sampling rate updated on both the ports>    
root@dut:/# show sflow interface
| Ethernet205 | up            |           10000 |
| Ethernet209 | up            |           10000 |

<disable autoneg> 
root@dut:/# config interface autoneg Ethernet209 disabled

root@dut:/# show sflow interface
| Ethernet205 | up            |           10000 |
| Ethernet209 | up            |           10000 |
```
