### PR TITLE
[coppmgrd] Use Producer del instead of del from Table

### DIFF
--- a/cfgmgr/coppmgr.cpp
+++ b/cfgmgr/coppmgr.cpp
@@ -285,7 +285,7 @@ bool CoppMgr::isDupEntry(const std::string &key, std::vector<FieldValueTuple> &f
             if ((!field_found) || (field_found && preserved_copp_it->second.compare(value)))
             {
                 // overwrite -> delete preserved entry from copp table and set a new entry instead
-                m_coppTable.del(key);
+                m_appCoppTable.del(key);
                 return false;
             }
         }
@@ -415,7 +415,7 @@ CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         auto copp_it = supported_copp_keys.find(it);
         if (copp_it == supported_copp_keys.end())
         {
-            m_coppTable.del(it);
+            m_appCoppTable.del(it);
         }
     }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

When handling the copp entries that are updated in new life, coppmgrd is deleting them directly from the table instead of using ProducerStateTable Del. Thus updated the value.

**Why i did it**

Without this, the copp traps are not created during reconciliation phase (because the key is deleted entirely from APP_DB) and are created at a later point. This would case a delay in LACP trap creation and would result in a 30 sec delay for the LACP sessions to be established and dplane downtime

**How I verified it**

Did a fastboot from 202205 -> 202305 (it had a difference in default copp fields and so the the del logic is triggered) and verified if the dplane downtime is < 30 sec

**Details if related**
