### PR TITLE
[fpmsyncd][WR] Relax the static schema constraint for ROUTE_TABLE

### DIFF
--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -53,6 +53,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 orchdaemon_ut.cpp \
                 intfsorch_ut.cpp \
                 mux_rollback_ut.cpp \
+                warmrestarthelper_ut.cpp \
                 warmrestartassist_ut.cpp \
                 test_failure_handling.cpp \
                 $(top_srcdir)/lib/gearboxutils.cpp \
@@ -126,6 +127,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/dash/dashvnetorch.cpp \
                 $(top_srcdir)/cfgmgr/buffermgrdyn.cpp \
                 $(top_srcdir)/warmrestart/warmRestartAssist.cpp \
+                $(top_srcdir)/warmrestart/warmRestartHelper.cpp \
                 $(top_srcdir)/orchagent/dash/pbutils.cpp
 
 tests_SOURCES += $(FLEX_CTR_DIR)/flex_counter_manager.cpp $(FLEX_CTR_DIR)/flex_counter_stat_manager.cpp $(FLEX_CTR_DIR)/flow_counter_handler.cpp $(FLEX_CTR_DIR)/flowcounterrouteorch.cpp

--- a/tests/mock_tests/warmrestarthelper_ut.cpp
+++ b/tests/mock_tests/warmrestarthelper_ut.cpp
@@ -1,0 +1,86 @@
+#include "warmRestartHelper.h"
+#include "warm_restart.h"
+#include "mock_table.h"
+#include "ut_helper.h"
+
+using namespace testing_db;
+
+namespace wrhelper_test
+{
+    struct WRHelperTest : public ::testing::Test
+    {
+        std::shared_ptr<swss::DBConnector> m_app_db;
+        std::shared_ptr<swss::RedisPipeline> m_pipeline;
+        std::shared_ptr<swss::Table> m_routeTable;
+        std::shared_ptr<swss::ProducerStateTable> m_routeProducerTable;
+        std::shared_ptr<swss::WarmStartHelper> wrHelper;
+
+        void SetUp() override
+        {
+            m_app_db = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+            m_pipeline = std::make_shared<swss::RedisPipeline>(m_app_db.get());
+            m_routeTable = std::make_shared<swss::Table>(m_app_db.get(), "ROUTE_TABLE");
+            m_routeProducerTable = std::make_shared<swss::ProducerStateTable>(m_app_db.get(), "ROUTE_TABLE");
+            wrHelper = std::make_shared<swss::WarmStartHelper>(m_pipeline.get(), m_routeProducerTable.get(), "ROUTE_TABLE", "bgp", "bgp");
+            testing_db::reset();
+        }
+
+        void TearDown() override {
+        }
+    };
+
+    TEST_F(WRHelperTest, testReconciliation)
+    {
+        /* Initialize WR */
+        wrHelper->setState(WarmStart::INITIALIZED);
+        ASSERT_EQ(wrHelper->getState(), WarmStart::INITIALIZED);
+
+        /* Old-life entries */
+        m_routeTable->set("1.0.0.0/24",
+                        {
+                            {"ifname", "eth1"},
+                            {"nexthop", "2.0.0.0"}
+                        });
+        m_routeTable->set("1.1.0.0/24",
+                        {
+                            {"ifname", "eth2"},
+                            {"nexthop", "2.1.0.0"},
+                            {"weight", "1"},
+                        });
+        wrHelper->runRestoration();
+        ASSERT_EQ(wrHelper->getState(), WarmStart::RESTORED);
+
+        /* Insert new life entries */
+        wrHelper->insertRefreshMap({
+                                    "1.0.0.0/24",
+                                    "SET",
+                                    {
+                                        {"ifname", "eth1"},
+                                        {"nexthop", "2.0.0.0"},
+                                        {"protocol", "kernel"}
+                                    }
+                                });
+        wrHelper->insertRefreshMap({
+                                    "1.1.0.0/24",
+                                    "SET",
+                                    {
+                                        {"ifname", "eth2"},
+                                        {"nexthop", "2.1.0.0,2.5.0.0"},
+                                        {"weight", "4"},
+                                        {"protocol", "kernel"}
+                                    }
+                                });
+        wrHelper->reconcile();
+        ASSERT_EQ(wrHelper->getState(), WarmStart::RECONCILED);
+
+        std::string val;
+        ASSERT_TRUE(m_routeTable->hget("1.0.0.0/24", "protocol", val));
+        ASSERT_EQ(val, "kernel");
+
+        m_routeTable->hget("1.1.0.0/24", "protocol", val);
+        ASSERT_EQ(val, "kernel");
+
+        m_routeTable->hget("1.1.0.0/24", "weight", val);
+        ASSERT_EQ(val, "4");
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Remove the assert when the schema changes and in that case, imply a diff and pass it down to orchagent

**Why I did it**

warmRestartHelper assumes a static schema during warm upgrade reconciliation. To overcome this, the db_migrator is used to add the missing fields in the ROUTE_TABLE. This is leading to control plane downtime exceeding 90 sec. 

**How I verified it**

UT:

```
vkarri@11ca2f5ec619:/sonic/src/sonic-swss/tests/mock_tests$ ./tests --gtest_filter="*WRHelper*"
Running main() from /build/googletest-YnT0O3/googletest-1.10.0.20201025/googletest/src/gtest_main.cc
Note: Google Test filter = *WRHelper*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from WRHelperTest
[ RUN      ] WRHelperTest.testReconciliation
[       OK ] WRHelperTest.testReconciliation (1 ms)
[----------] 1 test from WRHelperTest (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.
```

**Details if related**
