### PR TITLE
[DASH] Add support for ENI counters

### DIFF
--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -17,6 +17,7 @@
 #include "tokenize.h"
 #include "crmorch.h"
 #include "saihelper.h"
+#include "flex_counter_manager.h"
 
 #include "taskworker.h"
 #include "pbutils.h"
@@ -31,10 +32,38 @@ extern sai_dash_eni_api_t* sai_dash_eni_api;
 extern sai_object_id_t gSwitchId;
 extern size_t gMaxBulkSize;
 extern CrmOrch *gCrmOrch;
+extern bool gTraditionalFlexCounter;
 
-DashOrch::DashOrch(DBConnector *db, vector<string> &tableName, ZmqServer *zmqServer) : ZmqOrch(db, tableName, zmqServer)
+#define FLEX_COUNTER_UPD_INTERVAL 1
+
+DashOrch::DashOrch(DBConnector *db, vector<string> &tableName, ZmqServer *zmqServer) :
+    ZmqOrch(db, tableName, zmqServer),
+    m_eni_stat_manager(ENI_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, ENI_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false)
 {
     SWSS_LOG_ENTER();
+
+    m_asic_db = std::shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
+    m_counter_db = std::shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
+    m_eni_name_table = std::unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_ENI_NAME_MAP));
+
+    if (gTraditionalFlexCounter)
+    {
+        m_vid_to_rid_table = std::make_unique<Table>(m_asic_db.get(), "VIDTORID");
+    }
+
+    auto intervT = timespec { .tv_sec = FLEX_COUNTER_UPD_INTERVAL , .tv_nsec = 0 };
+    m_fc_update_timer = new SelectableTimer(intervT);
+    auto executorT = new ExecutableTimer(m_fc_update_timer, this, "FLEX_COUNTER_UPD_TIMER");
+    Orch::addExecutor(executorT);
+
+    /* Fetch the available counter Ids */
+    m_counter_stats.clear();
+    auto stat_enum_list = queryAvailableCounterStats((sai_object_type_t)SAI_OBJECT_TYPE_ENI);
+    for (auto &stat_enum: stat_enum_list)
+    {
+        auto counter_id = static_cast<sai_eni_stat_t>(stat_enum);
+        m_counter_stats.insert(sai_serialize_eni_stat(counter_id));
+    }
 }
 
 bool DashOrch::addApplianceEntry(const string& appliance_id, const dash::appliance::Appliance &entry)
@@ -370,6 +399,8 @@ bool DashOrch::addEniObject(const string& eni, EniEntry& entry)
         }
     }
 
+    addEniToFC(eni_id, eni);
+
     gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_DASH_ENI);
 
     SWSS_LOG_NOTICE("Created ENI object for %s", eni.c_str());
@@ -467,6 +498,8 @@ bool DashOrch::removeEniObject(const string& eni)
             return parseHandleSaiStatusFailure(handle_status);
         }
     }
+
+    removeEniFromFC(entry.eni_id, eni);
 
     gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_DASH_ENI);
 
@@ -680,5 +713,95 @@ void DashOrch::doTask(ConsumerBase& consumer)
     else
     {
         SWSS_LOG_ERROR("Unknown table: %s", tn.c_str());
+    }
+}
+
+void DashOrch::removeEniFromFC(sai_object_id_t oid, const string &name)
+{
+    SWSS_LOG_ENTER();
+
+    if (oid == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_WARN("Cannot remove counter on NULL OID for eni %s", name.c_str());
+        return;
+    }
+
+    if (m_eni_stat_work_queue.find(oid) != m_eni_stat_work_queue.end())
+    {
+        m_eni_stat_work_queue.erase(oid);
+        return;
+    }
+
+    m_eni_name_table->hdel("", name);
+    m_eni_stat_manager.clearCounterIdList(oid);
+    SWSS_LOG_DEBUG("Unregistered eni %s to Flex counter", name.c_str());
+}
+
+void DashOrch::clearEniFCStats()
+{
+    for (auto it = eni_entries_.begin(); it != eni_entries_.end(); it++)
+    {
+        removeEniFromFC(it->second.eni_id, it->first);
+    }
+}
+
+void DashOrch::handleFCStatusUpdate(bool enabled)
+{
+    if (!enabled && m_eni_fc_status)
+    {
+        m_fc_update_timer->stop();
+        clearEniFCStats();
+    }
+    else if (enabled && !m_eni_fc_status)
+    {
+        m_fc_update_timer->start();
+    }
+    m_eni_fc_status = enabled;
+}
+
+void DashOrch::addEniToFC(sai_object_id_t oid, const string &name)
+{
+    auto was_empty = m_eni_stat_work_queue.empty();
+    m_eni_stat_work_queue[oid] = name;
+    if (was_empty)
+    {
+        m_fc_update_timer->start();
+    }
+}
+
+void DashOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_ENTER();
+
+    if (!m_eni_fc_status)
+    {
+        m_fc_update_timer->stop();
+        return ;
+    }
+
+    for (auto it = m_eni_stat_work_queue.begin(); it != m_eni_stat_work_queue.end(); )
+    {
+        string value;
+        const auto id = sai_serialize_object_id(it->first);
+
+        if (!gTraditionalFlexCounter || m_vid_to_rid_table->hget("", id, value))
+        {
+            SWSS_LOG_INFO("Registering %s, id %s", it->second.c_str(), id.c_str());
+            std::vector<FieldValueTuple> eniNameFvs;
+            eniNameFvs.emplace_back(it->second, id);
+            m_eni_name_table->set("", eniNameFvs);
+
+            m_eni_stat_manager.setCounterIdList(it->first, CounterType::ENI, m_counter_stats);
+            it = m_eni_stat_work_queue.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    if (m_eni_stat_work_queue.empty())
+    {
+        m_fc_update_timer->stop();
     }
 }

--- a/orchagent/dash/dashorch.cpp
+++ b/orchagent/dash/dashorch.cpp
@@ -483,6 +483,9 @@ bool DashOrch::removeEniObject(const string& eni)
     SWSS_LOG_ENTER();
 
     EniEntry entry = eni_entries_[eni];
+
+    removeEniFromFC(entry.eni_id, eni);
+
     sai_status_t status = sai_dash_eni_api->remove_eni(entry.eni_id);
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -498,8 +501,6 @@ bool DashOrch::removeEniObject(const string& eni)
             return parseHandleSaiStatusFailure(handle_status);
         }
     }
-
-    removeEniFromFC(entry.eni_id, eni);
 
     gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_DASH_ENI);
 

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -17,11 +17,15 @@
 #include "timer.h"
 #include "zmqorch.h"
 #include "zmqserver.h"
+#include "flex_counter_manager.h"
 
 #include "dash_api/appliance.pb.h"
 #include "dash_api/route_type.pb.h"
 #include "dash_api/eni.pb.h"
 #include "dash_api/qos.pb.h"
+
+#define ENI_STAT_COUNTER_FLEX_COUNTER_GROUP "ENI_STAT_COUNTER"
+#define ENI_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS 10000
 
 struct EniEntry
 {
@@ -39,12 +43,14 @@ class DashOrch : public ZmqOrch
 public:
     DashOrch(swss::DBConnector *db, std::vector<std::string> &tables, swss::ZmqServer *zmqServer);
     const EniEntry *getEni(const std::string &eni) const;
+    void handleFCStatusUpdate(bool is_enabled);
 
 private:
     ApplianceTable appliance_entries_;
     RoutingTypeTable routing_type_entries_;
     EniTable eni_entries_;
     QosTable qos_entries_;
+
     void doTask(ConsumerBase &consumer);
     void doTaskApplianceTable(ConsumerBase &consumer);
     void doTaskRoutingTypeTable(ConsumerBase &consumer);
@@ -63,4 +69,20 @@ private:
     bool setEniAdminState(const std::string& eni, const EniEntry& entry);
     bool addQosEntry(const std::string& qos_name, const dash::qos::Qos &entry);
     bool removeQosEntry(const std::string& qos_name);
+
+private:
+    std::map<sai_object_id_t, std::string> m_eni_stat_work_queue;
+    FlexCounterManager m_eni_stat_manager;
+    bool m_eni_fc_status = false;
+    std::unordered_set<std::string> m_counter_stats;
+    std::unique_ptr<swss::Table> m_eni_name_table;
+    std::unique_ptr<swss::Table> m_vid_to_rid_table;
+    std::shared_ptr<swss::DBConnector> m_counter_db;
+    std::shared_ptr<swss::DBConnector> m_asic_db;
+    swss::SelectableTimer* m_fc_update_timer = nullptr;
+
+    void doTask(swss::SelectableTimer&);
+    void addEniToFC(sai_object_id_t oid, const std::string& name);
+    void removeEniFromFC(sai_object_id_t oid, const std::string& name);
+    void clearEniFCStats();
 };

--- a/orchagent/flex_counter/flex_counter_manager.cpp
+++ b/orchagent/flex_counter/flex_counter_manager.cpp
@@ -49,6 +49,7 @@ const unordered_map<CounterType, string> FlexCounterManager::counter_id_field_lo
     { CounterType::TUNNEL,          TUNNEL_COUNTER_ID_LIST },
     { CounterType::HOSTIF_TRAP,     FLOW_COUNTER_ID_LIST },
     { CounterType::ROUTE,           FLOW_COUNTER_ID_LIST },
+    { CounterType::ENI,             ENI_COUNTER_ID_LIST },
 };
 
 FlexManagerDirectory g_FlexManagerDirectory;

--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -32,6 +32,7 @@ enum class CounterType
     TUNNEL,
     HOSTIF_TRAP,
     ROUTE,
+    ENI
 };
 
 // FlexCounterManager allows users to manage a group of flex counters.

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -13,6 +13,7 @@
 #include <swss/tokenize.h>
 #include "routeorch.h"
 #include "macsecorch.h"
+#include "dash/dashorch.h"
 #include "flowcounterrouteorch.h"
 
 extern sai_port_api_t *sai_port_api;
@@ -39,6 +40,7 @@ extern sai_object_id_t gSwitchId;
 #define TUNNEL_KEY                  "TUNNEL"
 #define FLOW_CNT_TRAP_KEY           "FLOW_CNT_TRAP"
 #define FLOW_CNT_ROUTE_KEY          "FLOW_CNT_ROUTE"
+#define ENI_KEY                     "ENI"
 
 unordered_map<string, string> flexCounterGroupMap =
 {
@@ -61,6 +63,7 @@ unordered_map<string, string> flexCounterGroupMap =
     {"MACSEC_SA", COUNTERS_MACSEC_SA_GROUP},
     {"MACSEC_SA_ATTR", COUNTERS_MACSEC_SA_ATTR_GROUP},
     {"MACSEC_FLOW", COUNTERS_MACSEC_FLOW_GROUP},
+    {"ENI", ENI_STAT_COUNTER_FLEX_COUNTER_GROUP}
 };
 
 
@@ -84,6 +87,7 @@ void FlexCounterOrch::doTask(Consumer &consumer)
     SWSS_LOG_ENTER();
 
     VxlanTunnelOrch* vxlan_tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+    DashOrch* dash_orch = gDirectory.get<DashOrch*>();
     if (gPortsOrch && !gPortsOrch->allPortsReady())
     {
         return;
@@ -199,6 +203,10 @@ void FlexCounterOrch::doTask(Consumer &consumer)
                     if (vxlan_tunnel_orch && (key== TUNNEL_KEY) && (value == "enable"))
                     {
                         vxlan_tunnel_orch->generateTunnelCounterMap();
+                    }
+                    if (dash_orch && (key == ENI_KEY))
+                    {
+                        dash_orch->handleFCStatusUpdate((value == "enable"));
                     }
                     if (gCoppOrch && (key == FLOW_CNT_TRAP_KEY))
                     {

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -1100,3 +1100,26 @@ void stopFlexCounterPolling(sai_object_id_t switch_oid,
 
     sai_switch_api->set_switch_attribute(switch_oid, &attr);
 }
+
+/*
+    Use metadata info of the SAI object to infer all the available stats
+    Syncd already has logic to filter out the supported stats
+*/
+std::vector<sai_stat_id_t> queryAvailableCounterStats(const sai_object_type_t object_type)
+{
+    std::vector<sai_stat_id_t> stat_list;
+    auto info = sai_metadata_get_object_type_info(object_type);
+
+    SWSS_LOG_NOTICE("SAI object %s supports stat type %s",
+            sai_serialize_object_type(object_type).c_str(),
+            info->statenum->name);
+
+    auto statenumlist = info->statenum->values;
+    auto statnumcount = (uint32_t)info->statenum->valuescount;
+
+    for (uint32_t i = 0; i < statnumcount; i++)
+    {
+        stat_list.push_back(static_cast<sai_stat_id_t>(statenumlist[i]));
+    }
+    return stat_list;
+}

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -1116,6 +1116,7 @@ std::vector<sai_stat_id_t> queryAvailableCounterStats(const sai_object_type_t ob
 
     auto statenumlist = info->statenum->values;
     auto statnumcount = (uint32_t)info->statenum->valuescount;
+    stat_list.reserve(statnumcount);
 
     for (uint32_t i = 0; i < statnumcount; i++)
     {

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -49,3 +49,5 @@ void startFlexCounterPolling(sai_object_id_t switch_oid,
                              const std::string &stats_mode="");
 void stopFlexCounterPolling(sai_object_id_t switch_oid,
                             const std::string &key);
+
+std::vector<sai_stat_id_t> queryAvailableCounterStats(const sai_object_type_t);

--- a/tests/dvslib/dvs_flex_counter.py
+++ b/tests/dvslib/dvs_flex_counter.py
@@ -1,0 +1,120 @@
+import time
+
+NUMBER_OF_RETRIES = 10
+
+class TestFlexCountersBase(object):
+
+    def setup_dbs(self, dvs):
+        self.config_db = dvs.get_config_db()
+        self.flex_db = dvs.get_flex_db()
+        self.counters_db = dvs.get_counters_db()
+        self.app_db = dvs.get_app_db()
+
+    def wait_for_table(self, table):
+        for retry in range(NUMBER_OF_RETRIES):
+            counters_keys = self.counters_db.db_connection.hgetall(table)
+            if len(counters_keys) > 0:
+                return
+            else:
+                time.sleep(1)
+
+        assert False, str(table) + " not created in Counters DB"
+
+    def wait_for_table_empty(self, table):
+        for retry in range(NUMBER_OF_RETRIES):
+            counters_keys = self.counters_db.db_connection.hgetall(table)
+            if len(counters_keys) == 0:
+                return
+            else:
+                time.sleep(1)
+
+        assert False, str(table) + " is still in Counters DB"
+
+    def wait_for_id_list(self, stat, name, oid):
+        for retry in range(NUMBER_OF_RETRIES):
+            id_list = self.flex_db.db_connection.hgetall("FLEX_COUNTER_TABLE:" + stat + ":" + oid).items()
+            if len(id_list) > 0:
+                return
+            else:
+                time.sleep(1)
+
+        assert False, "No ID list for counter " + str(name)
+
+    def wait_for_id_list_remove(self, stat, name, oid):
+        for retry in range(NUMBER_OF_RETRIES):
+            id_list = self.flex_db.db_connection.hgetall("FLEX_COUNTER_TABLE:" + stat + ":" + oid).items()
+            if len(id_list) == 0:
+                return
+            else:
+                time.sleep(1)
+
+        assert False, "ID list for counter " + str(name) + " is still there"
+
+    def wait_for_interval_set(self, group, interval):
+        interval_value = None
+        for retry in range(NUMBER_OF_RETRIES):
+            interval_value = self.flex_db.db_connection.hget("FLEX_COUNTER_GROUP_TABLE:" + group, 'POLL_INTERVAL')
+            if interval_value == interval:
+                return
+            else:
+                time.sleep(1)
+
+        assert False, "Polling interval is not applied to FLEX_COUNTER_GROUP_TABLE for group {}, expect={}, actual={}".format(group, interval, interval_value)
+
+    def set_flex_counter_group_status(self, group, map, status='enable', check_name_map=True):
+        group_stats_entry = {"FLEX_COUNTER_STATUS": status}
+        self.config_db.create_entry("FLEX_COUNTER_TABLE", group, group_stats_entry)
+        if check_name_map:
+            if status == 'enable':
+                self.wait_for_table(map)
+            else:
+                self.wait_for_table_empty(map)
+
+    def verify_flex_counters_populated(self, map, stat):
+        counters_keys = self.counters_db.db_connection.hgetall(map)
+        for counter_entry in counters_keys.items():
+            name = counter_entry[0]
+            oid = counter_entry[1]
+            self.wait_for_id_list(stat, name, oid)
+
+    def set_flex_counter_group_interval(self, key, group, interval):
+        group_stats_entry = {"POLL_INTERVAL": interval}
+        self.config_db.create_entry("FLEX_COUNTER_TABLE", key, group_stats_entry)
+        self.wait_for_interval_set(group, interval)
+
+    def verify_no_flex_counters_tables(self, counter_stat):
+        counters_stat_keys = self.flex_db.get_keys("FLEX_COUNTER_TABLE:" + counter_stat)
+        assert len(counters_stat_keys) == 0, "FLEX_COUNTER_TABLE:" + str(counter_stat) + " tables exist before enabling the flex counter group"
+
+    def verify_flex_counter_flow(self, dvs, meta_data):
+        """
+        The test will check there are no flex counters tables on FlexCounter DB when the counters are disabled.
+        After enabling each counter group, the test will check the flow of creating flex counters tables on FlexCounter DB.
+        For some counter types the MAPS on COUNTERS DB will be created as well after enabling the counter group, this will be also verified on this test.
+        """
+        self.setup_dbs(dvs)
+        counter_key = meta_data['key']
+        counter_stat = meta_data['group_name']
+        counter_map = meta_data['name_map']
+        pre_test = meta_data.get('pre_test')
+        post_test = meta_data.get('post_test')
+        meta_data['dvs'] = dvs
+
+        self.verify_no_flex_counters_tables(counter_stat)
+
+        if pre_test:
+            if not hasattr(self, pre_test):
+                assert False, "Test object does not have the method {}".format(pre_test)
+            cb = getattr(self, pre_test)
+            cb(meta_data)
+
+        self.set_flex_counter_group_status(counter_key, counter_map)
+        self.verify_flex_counters_populated(counter_map, counter_stat)
+        self.set_flex_counter_group_interval(counter_key, counter_stat, '2500')
+
+        if post_test:
+            if not hasattr(self, post_test):
+                assert False, "Test object does not have the method {}".format(post_test)
+            cb = getattr(self, post_test)
+            cb(meta_data)
+


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

- Added support for ENI Counters
- Refactored Flex Counter VS test to move the common infra logic and re-use in the dash vs tests

**Why I did it**

**How I verified it**

- Add a VS test
- Test Counters creation in VS Setup

**Enable Flex Counter Creation:**

```
<Enable FC for ENI>
sonic-db-cli CONFIG_DB HSET "FLEX_COUNTER_TABLE|ENI" FLEX_COUNTER_STATUS enable

<Check the FC Group Entry>
sonic-db-cli FLEX_COUNTER_DB HGETALL FLEX_COUNTER_GROUP_TABLE:ENI_STAT_COUNTER
{'POLL_INTERVAL': '10000', 'STATS_MODE': 'STATS_MODE_READ', 'FLEX_COUNTER_STATUS': 'enable'}

<Check the Counter ID list>
sonic-db-cli FLEX_COUNTER_DB HGETALL FLEX_COUNTER_TABLE:ENI_STAT_COUNTER:oid:0x76000000000027
{'ENI_COUNTER_ID_LIST': 'SAI_ENI_STAT_TIMED_FLOW_DELETE_ACK_FAILED_RECV,SAI_ENI_STAT_TIMED_FLOW_DELETE_REQ_FAILED,SAI_ENI_STAT_TIMED_FLOW_DELETE_REQ_RECV,SAI_ENI_STAT_TIMED_FLOW_DELETE_REQ_SENT,SAI_ENI_STAT_INLINE_FLOW_DELETE_ACK_FAILED_RECV,SAI_ENI_STAT_INBOUND_RX_PACKETS,SAI_ENI_STAT_TIMED_SYNC_PACKET_RX_BYTES,SAI_ENI_STAT_INLINE_SYNC_PACKET_TX_BYTES,SAI_ENI_STAT_TIMED_FLOW_CREATE_REQ_SENT,SAI_ENI_STAT_INLINE_FLOW_UPDATE_ACK_IGNORED_RECV,SAI_ENI_STAT_FLOW_DELETED,SAI_ENI_STAT_INLINE_FLOW_DELETE_ACK_IGNORED_RECV,SAI_ENI_STAT_LB_FAST_PATH_ICMP_IN_BYTES,SAI_ENI_STAT_FLOW_UPDATE_BY_RESIMULATION_FAILED,SAI_ENI_STAT_TIMED_FLOW_DELETE_ACK_RECV,SAI_ENI_STAT_FLOW_UPDATED,SAI_ENI_STAT_OUTBOUND_TX_PACKETS,SAI_ENI_STAT_INLINE_SYNC_PACKET_RX_BYTES,SAI_ENI_STAT_TIMED_SYNC_PACKET_TX_BYTES,SAI_ENI_STAT_TIMED_FLOW_UPDATE_REQ_SENT,SAI_ENI_STAT_TIMED_FLOW_UPDATE_ACK_FAILED_RECV,SAI_ENI_STAT_FLOW_CREATE_FAILED,SAI_ENI_STAT_INLINE_FLOW_CREATE_ACK_RECV,SAI_ENI_STAT_RX_PACKETS,SAI_ENI_STAT_INBOUND_RX_BYTES,SAI_ENI_STAT_INLINE_SYNC_PACKET_RX_PACKETS,SAI_ENI_STAT_INLINE_FLOW_CREATE_ACK_IGNORED_RECV,SAI_ENI_STAT_TX_BYTES,SAI_ENI_STAT_INLINE_FLOW_DELETE_REQ_FAILED,SAI_ENI_STAT_FLOW_AGED,SAI_ENI_STAT_FLOW_UPDATE_FAILED,SAI_ENI_STAT_OUTBOUND_RX_BYTES,SAI_ENI_STAT_INBOUND_TX_BYTES,SAI_ENI_STAT_OUTBOUND_RX_PACKETS,SAI_ENI_STAT_RX_BYTES,SAI_ENI_STAT_LB_FAST_PATH_ICMP_IN_PACKETS,SAI_ENI_STAT_INBOUND_TX_PACKETS,SAI_ENI_STAT_FLOW_CREATED,SAI_ENI_STAT_INLINE_FLOW_UPDATE_REQ_FAILED,SAI_ENI_STAT_TIMED_SYNC_PACKET_TX_PACKETS,SAI_ENI_STAT_INLINE_FLOW_UPDATE_REQ_SENT,SAI_ENI_STAT_TIMED_FLOW_UPDATE_ACK_IGNORED_RECV,SAI_ENI_STAT_FLOW_DELETE_FAILED,SAI_ENI_STAT_INLINE_FLOW_CREATE_REQ_SENT,SAI_ENI_STAT_INLINE_FLOW_CREATE_REQ_RECV,SAI_ENI_STAT_TIMED_FLOW_CREATE_REQ_RECV,SAI_ENI_STAT_TIMED_FLOW_UPDATE_REQ_RECV,SAI_ENI_STAT_INLINE_FLOW_CREATE_REQ_FAILED,SAI_ENI_STAT_INLINE_FLOW_DELETE_ACK_RECV,SAI_ENI_STAT_INLINE_FLOW_CREATE_ACK_FAILED_RECV,SAI_ENI_STAT_TIMED_SYNC_PACKET_RX_PACKETS,SAI_ENI_STAT_FLOW_UPDATED_BY_RESIMULATION,SAI_ENI_STAT_TIMED_FLOW_CREATE_ACK_RECV,SAI_ENI_STAT_INLINE_FLOW_DELETE_REQ_RECV,SAI_ENI_STAT_TIMED_FLOW_CREATE_ACK_FAILED_RECV,SAI_ENI_STAT_INLINE_FLOW_UPDATE_REQ_RECV,SAI_ENI_STAT_INLINE_SYNC_PACKET_TX_PACKETS,SAI_ENI_STAT_TIMED_FLOW_CREATE_ACK_IGNORED_RECV,SAI_ENI_STAT_TIMED_FLOW_DELETE_ACK_IGNORED_RECV,SAI_ENI_STAT_OUTBOUND_TX_BYTES,SAI_ENI_STAT_INLINE_FLOW_UPDATE_ACK_RECV,SAI_ENI_STAT_INLINE_FLOW_UPDATE_ACK_FAILED_RECV,SAI_ENI_STAT_TIMED_FLOW_CREATE_REQ_FAILED,SAI_ENI_STAT_TIMED_FLOW_UPDATE_REQ_FAILED,SAI_ENI_STAT_TIMED_FLOW_UPDATE_ACK_RECV,SAI_ENI_STAT_TX_PACKETS,SAI_ENI_STAT_INLINE_FLOW_DELETE_REQ_SENT'}

sonic-db-cli COUNTERS_DB HGETALL "COUNTERS_ENI_NAME_MAP"
{'eth0': 'oid:0x76000000000027'}

sonic-db-cli COUNTERS_DB hgetall COUNTERS:oid:0x76000000000027
{'SAI_ENI_STAT_TIMED_FLOW_DELETE_ACK_FAILED_RECV': '0', 'SAI_ENI_STAT_TIMED_FLOW_DELETE_REQ_FAILED': '0', 'SAI_ENI_STAT_TIMED_FLOW_DELETE_REQ_RECV': '0', 'SAI_ENI_STAT_TIMED_FLOW_DELETE_REQ_SENT': '0', 'SAI_ENI_STAT_INLINE_FLOW_DELETE_ACK_FAILED_RECV': '0', 'SAI_ENI_STAT_INBOUND_RX_PACKETS': '0', 'SAI_ENI_STAT_TIMED_SYNC_PACKET_RX_BYTES': '0', 'SAI_ENI_STAT_INLINE_SYNC_PACKET_TX_BYTES': '0', 'SAI_ENI_STAT_TIMED_FLOW_CREATE_REQ_SENT': '0', 'SAI_ENI_STAT_INLINE_FLOW_UPDATE_ACK_IGNORED_RECV': '0', 'SAI_ENI_STAT_FLOW_DELETED': '0', 'SAI_ENI_STAT_INLINE_FLOW_DELETE_ACK_IGNORED_RECV': '0', 'SAI_ENI_STAT_LB_FAST_PATH_ICMP_IN_BYTES': '0', 'SAI_ENI_STAT_FLOW_UPDATE_BY_RESIMULATION_FAILED': '0', 'SAI_ENI_STAT_TIMED_FLOW_DELETE_ACK_RECV': '0', 'SAI_ENI_STAT_FLOW_UPDATED': '0', 'SAI_ENI_STAT_OUTBOUND_TX_PACKETS': '0', 'SAI_ENI_STAT_INLINE_SYNC_PACKET_RX_BYTES': '0', 'SAI_ENI_STAT_TIMED_SYNC_PACKET_TX_BYTES': '0', 'SAI_ENI_STAT_TIMED_FLOW_UPDATE_REQ_SENT': '0', 'SAI_ENI_STAT_TIMED_FLOW_UPDATE_ACK_FAILED_RECV': '0', 'SAI_ENI_STAT_FLOW_CREATE_FAILED': '0', 'SAI_ENI_STAT_INLINE_FLOW_CREATE_ACK_RECV': '0', 'SAI_ENI_STAT_RX_PACKETS': '0', 'SAI_ENI_STAT_INBOUND_RX_BYTES': '0', 'SAI_ENI_STAT_INLINE_SYNC_PACKET_RX_PACKETS': '0', 'SAI_ENI_STAT_INLINE_FLOW_CREATE_ACK_IGNORED_RECV': '0', 'SAI_ENI_STAT_TX_BYTES': '0', 'SAI_ENI_STAT_INLINE_FLOW_DELETE_REQ_FAILED': '0', 'SAI_ENI_STAT_FLOW_AGED': '0', 'SAI_ENI_STAT_FLOW_UPDATE_FAILED': '0', 'SAI_ENI_STAT_OUTBOUND_RX_BYTES': '0', 'SAI_ENI_STAT_INBOUND_TX_BYTES': '0', 'SAI_ENI_STAT_OUTBOUND_RX_PACKETS': '0', 'SAI_ENI_STAT_RX_BYTES': '0', 'SAI_ENI_STAT_LB_FAST_PATH_ICMP_IN_PACKETS': '0', 'SAI_ENI_STAT_INBOUND_TX_PACKETS': '0', 'SAI_ENI_STAT_FLOW_CREATED': '0', 'SAI_ENI_STAT_INLINE_FLOW_UPDATE_REQ_FAILED': '0', 'SAI_ENI_STAT_TIMED_SYNC_PACKET_TX_PACKETS': '0', 'SAI_ENI_STAT_INLINE_FLOW_UPDATE_REQ_SENT': '0', 'SAI_ENI_STAT_TIMED_FLOW_UPDATE_ACK_IGNORED_RECV': '0', 'SAI_ENI_STAT_FLOW_DELETE_FAILED': '0', 'SAI_ENI_STAT_INLINE_FLOW_CREATE_REQ_SENT': '0', 'SAI_ENI_STAT_INLINE_FLOW_CREATE_REQ_RECV': '0', 'SAI_ENI_STAT_TIMED_FLOW_CREATE_REQ_RECV': '0', 'SAI_ENI_STAT_TIMED_FLOW_UPDATE_REQ_RECV': '0', 'SAI_ENI_STAT_INLINE_FLOW_CREATE_REQ_FAILED': '0', 'SAI_ENI_STAT_INLINE_FLOW_DELETE_ACK_RECV': '0', 'SAI_ENI_STAT_INLINE_FLOW_CREATE_ACK_FAILED_RECV': '0', 'SAI_ENI_STAT_TIMED_SYNC_PACKET_RX_PACKETS': '0', 'SAI_ENI_STAT_FLOW_UPDATED_BY_RESIMULATION': '0', 'SAI_ENI_STAT_TIMED_FLOW_CREATE_ACK_RECV': '0', 'SAI_ENI_STAT_INLINE_FLOW_DELETE_REQ_RECV': '0', 'SAI_ENI_STAT_TIMED_FLOW_CREATE_ACK_FAILED_RECV': '0', 'SAI_ENI_STAT_INLINE_FLOW_UPDATE_REQ_RECV': '0', 'SAI_ENI_STAT_INLINE_SYNC_PACKET_TX_PACKETS': '0', 'SAI_ENI_STAT_TIMED_FLOW_CREATE_ACK_IGNORED_RECV': '0', 'SAI_ENI_STAT_TIMED_FLOW_DELETE_ACK_IGNORED_RECV': '0', 'SAI_ENI_STAT_OUTBOUND_TX_BYTES': '0', 'SAI_ENI_STAT_INLINE_FLOW_UPDATE_ACK_RECV': '0', 'SAI_ENI_STAT_INLINE_FLOW_UPDATE_ACK_FAILED_RECV': '0', 'SAI_ENI_STAT_TIMED_FLOW_CREATE_REQ_FAILED': '0', 'SAI_ENI_STAT_TIMED_FLOW_UPDATE_REQ_FAILED': '0', 'SAI_ENI_STAT_TIMED_FLOW_UPDATE_ACK_RECV': '0', 'SAI_ENI_STAT_TX_PACKETS': '0', 'SAI_ENI_STAT_INLINE_FLOW_DELETE_REQ_SENT': '0'}
```


**Details if related**
