### PR TITLE
[Dash] Handle FC update for existing ENI objects

### DIFF
--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -97,5 +97,5 @@ private:
     void doTask(swss::SelectableTimer&);
     void addEniToFC(sai_object_id_t oid, const std::string& name);
     void removeEniFromFC(sai_object_id_t oid, const std::string& name);
-    void clearEniFCStats();
+    void refreshEniFCStats(bool);
 };


### PR DESCRIPTION
**Why I did**

When FC is enabled after being disabled, FlexCounters are not installed for existing ENI's.

**What I did**

Fix the flow.

**How I verified it**

**Create ENI, By default FC is enabled on DPU**
```
2024 Nov 13 00:53:05.218187 sonic INFO swss#orchagent: :- doTask: Registering FC for ENI: 497f23d7-f0ac-4c99-a98f-59b470e8c7bd, id oid:0x7008000000020
root@sonic:/home/admin# sonic-db-cli COUNTERS_DB hgetall COUNTERS:oid:0x7008000000020
{ 'SAI_ENI_STAT_OUTBOUND_RX_PACKETS': '21', ……..}
root@sonic:/home/admin# sonic-db-cli COUNTERS_DB HGETALL "COUNTERS_ENI_NAME_MAP"
{'497f23d7-f0ac-4c99-a98f-59b470e8c7bd': 'oid:0x7008000000020'}
```

**Disable ENI, this removes FC**
```
root@sonic:/home/admin# counterpoll eni disable
2024 Nov 13 00:54:58.667654 sonic INFO swss#orchagent: :- removeEniFromFC: Unregistering FC for 497f23d7-f0ac-4c99-a98f-59b470e8c7bd, id: oid:0x7008000000020
root@sonic:/home/admin#  COUNTERS:oid:0x7008000000020
root@sonic:/home/admin# sonic-db-cli COUNTERS_DB HGETALL "COUNTERS_ENI_NAME_MAP"
{}
```

**Re-enable FC,**
```
root@sonic:/home/admin# counterpoll eni enable
2024 Nov 13 00:55:30.715809 sonic INFO swss#orchagent: :- doTask: Registering FC for ENI: 497f23d7-f0ac-4c99-a98f-59b470e8c7bd, id oid:0x7008000000020
root@sonic:/home/admin# sonic-db-cli COUNTERS_DB HGETALL "COUNTERS_ENI_NAME_MAP"
{'497f23d7-f0ac-4c99-a98f-59b470e8c7bd': 'oid:0x7008000000020'}

<Send 10 pkts>
testutils.send(ptfadapter, dash_pl_config[LOCAL_PTF_INTF], pkt, 10)
root@sonic:/home/admin# sonic-db-cli COUNTERS_DB hgetall COUNTERS:oid:0x7008000000020
{'SAI_ENI_STAT_OUTBOUND_RX_PACKETS': '31'}
```

**Details if related**
