### PR TITLE
[FC] Fix the cache to handle change in stats for the same object type

### DIFF
--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -187,8 +187,11 @@ struct CachedObjects
         counter_keys.pop_back();
 
         startFlexCounterPolling(pending_switch_id, counter_keys, counter_ids, counter_type_it->second);
-
+        
+        /* Clear the cached stats and objects after flush */
         pending_sai_objects.clear();
+        pending_counter_stats.clear();
+        pending_switch_id = SAI_NULL_OBJECT_ID;
     }
 
     void cache(sai_object_id_t object_id)
@@ -242,8 +245,12 @@ class FlexCounterCachedManager : public FlexCounterManager
             }
             else
             {
+                // Either counter_type, counter_ids or switch_id has changed in the new entry 
+                // Flush the old entries and save the new one 
+                // TODO: Improve the logic to read all the entries and group them before flushing 
+                //       to reduce number of sairedis calls
                 flush(group_name, cached_objects);
-                cached_objects.cache(object_id);
+                cached_objects.try_cache(object_id, counter_type, counter_stats, effective_switch_id);
             }
         }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix the bug in FlexCounter Bulk Init caching logic which is causing the correct counters to not be polled

**Why I did it**

We observed test failures when trying to enable pfcwd on non-default lossless TC's

**How I verified it**

1) Run `config qos reload, config save -y`
2) Edit the config to make TC 5 for Ethernet16 lossless
```
{
    "BUFFER_QUEUE" : {
        "Ethernet16|5": {
            "profile" : "egress_lossless_profile"
        },
        "Ethernet16|6": {
            "profile" : "q_lossy_profile"
        }
    },
    "BUFFER_PG" : {
        "Ethernet16|5" : {
            "profile" : "NULL"
        }
    },
    "QUEUE" : {
        "Ethernet16|5": {
            "scheduler": "scheduler.1",
            "wred_profile": "AZURE_LOSSLESS"
        }
    },
    "PORT_QOS_MAP" : {
        "Ethernet16": {
            "dscp_to_tc_map": "AZURE",
            "pfc_enable": "3,4,5",
            "pfc_to_pg_map": "AZURE",
            "pfc_to_queue_map": "AZURE",
            "pfcwd_sw_enable": "3,4,5",
            "tc_to_pg_map": "AZURE",
            "tc_to_queue_map": "AZURE"
        }
    }
}
```
3) Run `config reload -y`
4) Enable PFCWD
```
config pfcwd counter_poll enable
config pfcwd interval 100
config pfcwd start --action drop ports all detection-time 200 --restoration-time 200
```

**Check sairedis.rec:**

Get the oid of Ethernet16
```
root@sonic:/home/admin# sonic-db-cli COUNTERS_DB HGET "COUNTERS_PORT_NAME_MAP" "Ethernet16"
oid:0x100000000000f
```

Please note that ID's before the fix for `0x100000000000f` does not include `SAI_PORT_STAT_PFC_5_RX_PKTS` & `SAI_PORT_STAT_PFC_5_RX_PAUSE_DURATION_US`, which are needed by pfcwd lua scripts to determine if there is a storm on the queue


Before the fix:
```
2025-05-21.04:27:44.739387|p|PFC_WD:oid:0x100000000000d|PORT_COUNTER_ID_LIST=SAI_PORT_STAT_PFC_4_RX_PKTS,SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PKTS
2025-05-21.04:27:44.744357|p|PFC_WD:oid:0x100000000000e,oid:0x1000000000015,oid:0x1000000000014,oid:0x1000000000013,oid:0x1000000000012,oid:0x1000000000011,oid:0x1000000000010,oid:0x100000000000f|PORT_COUNTER_ID_LIST=SAI_PORT_STAT_PFC_4_RX_PKTS,SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PKTS
2025-05-21.04:27:44.762451|p|PFC_WD:oid:0x1000000000019,oid:0x1000000000018,oid:0x1000000000017,oid:0x1000000000016,oid:0x1000000000028,oid:0x1000000000027,oid:0x100000000001a,oid:0x100000000001b,oid:0x100000000001c,oid:0x100000000001d,oid:0x100000000001e,oid:0x100000000001f,oid:0x1000000000020,oid:0x1000000000021,oid:0x1000000000022,oid:0x1000000000023,oid:0x1000000000024,oid:0x1000000000025,oid:0x1000000000026|PORT_COUNTER_ID_LIST=SAI_PORT_STAT_PFC_4_RX_PKTS,SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PKTS
```

After the fix:
```
2025-05-21.04:40:22.094469|p|PFC_WD:oid:0x100000000000d|PORT_COUNTER_ID_LIST=SAI_PORT_STAT_PFC_4_RX_PKTS,SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PKTS
2025-05-21.04:40:22.099434|p|PFC_WD:oid:0x100000000000f|PORT_COUNTER_ID_LIST=SAI_PORT_STAT_PFC_4_RX_PKTS,SAI_PORT_STAT_PFC_5_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PKTS,SAI_PORT_STAT_PFC_5_RX_PKTS
2025-05-21.04:40:22.104669|p|PFC_WD:oid:0x1000000000019,oid:0x1000000000018,oid:0x1000000000017,oid:0x100000000000e,oid:0x1000000000016,oid:0x1000000000015,oid:0x1000000000014,oid:0x1000000000013,oid:0x1000000000012,oid:0x1000000000011,oid:0x1000000000010|PORT_COUNTER_ID_LIST=SAI_PORT_STAT_PFC_4_RX_PKTS,SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PKTS
2025-05-21.04:40:22.120162|p|PFC_WD:oid:0x1000000000028,oid:0x1000000000027,oid:0x100000000001a,oid:0x100000000001b,oid:0x100000000001c,oid:0x100000000001d,oid:0x100000000001e,oid:0x100000000001f,oid:0x1000000000020,oid:0x1000000000021,oid:0x1000000000022,oid:0x1000000000023,oid:0x1000000000024,oid:0x1000000000025,oid:0x1000000000026|PORT_COUNTER_ID_LIST=SAI_PORT_STAT_PFC_4_RX_PKTS,SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US,SAI_PORT_STAT_PFC_3_RX_PKTS
```


**Details if related**
