### PR TITLE
[Dash] Only set relevant attributes for Floating NIC

### DIFF
--- a/tests/dash/test_dash_vnet.py
+++ b/tests/dash/test_dash_vnet.py
@@ -60,7 +60,6 @@ class TestDash(TestFlexCountersBase):
         direction_keys = dash_db.wait_for_asic_db_keys(ASIC_DIRECTION_LOOKUP_TABLE)
         dl_attrs = dash_db.get_asic_db_entry(ASIC_DIRECTION_LOOKUP_TABLE, direction_keys[0])
         assert_sai_attribute_exists("SAI_DIRECTION_LOOKUP_ENTRY_ATTR_ACTION", dl_attrs, "SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_INBOUND_DIRECTION")
-        assert_sai_attribute_exists("SAI_DIRECTION_LOOKUP_ENTRY_ATTR_DASH_ENI_MAC_OVERRIDE_TYPE", dl_attrs, "SAI_DASH_ENI_MAC_OVERRIDE_TYPE_DST_MAC")
         dash_db.remove_appliance(self.appliance_id)
         time.sleep(2)
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Don't set SAI_DIRECTION_LOOKUP_ENTRY_ATTR_DASH_ENI_MAC_OVERRIDE_TYPE for Floating NIC i.e. when outbound_dir_lookup == "dst_mac"

**Why I did it**

Overriding MAC is implied in FNIC. This attribute holds no meaning for FNIC

**How I verified it**

UT and verified by loading and running the FNIC sonic-mgmt tests

**Details if related**
