### PR TITLE
[DASH] Query support for ADMIN_STATE and IS_HA_FLOW_OWNER attributes

### DIFF
--- a/orchagent/dash/dashhaorch.h
+++ b/orchagent/dash/dashhaorch.h
@@ -1,6 +1,7 @@
 #ifndef DASHHAORCH_H
 #define DASHHAORCH_H
 #include <map>
+#include <mutex>
 
 #include "dbconnector.h"
 #include "dashorch.h"
@@ -71,6 +72,7 @@ protected:
     bool setHaScopeFlowReconcileRequest(const  std::string &key);
     bool setHaScopeActivateRoleRequest(const std::string &key);
     bool setHaScopeDisabled(const std::string &key, bool disabled);
+    bool isHaScopeAdminStateAttrSupported();
     bool setEniHaScopeId(const sai_object_id_t eni_id, const sai_object_id_t ha_scope_id);
     bool register_ha_set_notifier();
     bool register_ha_scope_notifier();
@@ -106,6 +108,9 @@ protected:
 
     swss::NotificationConsumer* m_haSetNotificationConsumer;
     swss::NotificationConsumer* m_haScopeNotificationConsumer;
+
+    bool m_ha_scope_admin_state_attr_supported = false;
+    std::once_flag m_ha_scope_admin_state_attr_once_flag;
 
 public:
     const HaSetTable& getHaSetEntries() const { return m_ha_set_entries; };

--- a/orchagent/dash/dashorch.h
+++ b/orchagent/dash/dashorch.h
@@ -102,6 +102,7 @@ private:
     bool removeQosEntry(const std::string& qos_name);
     bool setEniRoute(const std::string& eni, const dash::eni_route::EniRoute& entry);
     bool removeEniRoute(const std::string& eni);
+    bool isHaFlowOwnerAttrSupported();
 
 private:
 
@@ -172,6 +173,8 @@ private:
     std::shared_ptr<swss::DBConnector> m_counter_db;
     std::shared_ptr<swss::DBConnector> m_asic_db;
     DashHaOrch* m_dash_ha_orch = nullptr;
+    bool m_ha_flow_owner_attr_supported = false;
+    std::once_flag m_ha_flow_owner_attr_once_flag;
 
     void addEniMapEntry(sai_object_id_t oid, const std::string& name);
     void removeEniMapEntry(sai_object_id_t oid, const std::string& name);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Query these attributes before programming

**Why I did it**

Not all vendors support these attributes

**How I verified it**

Apply HA_SCOPE and ENI configuration and verify

```
|q|attribute_capability|SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000|OBJECT_TYPE=SAI_OBJECT_TYPE_HA_SCOPE|ATTR_ID=SAI_HA_SCOPE_ATTR_ADMIN_STATE
|Q|attribute_capability|SAI_STATUS_SUCCESS|OBJECT_TYPE=SAI_OBJECT_TYPE_HA_SCOPE|ATTR_ID=SAI_HA_SCOPE_ATTR_ADMIN_STATE|CREATE_IMP=false|SET_IMP=false|GET_IMP=false
|c|SAI_OBJECT_TYPE_HA_SCOPE:oid:0x12008000000021|SAI_HA_SCOPE_ATTR_HA_SET_ID=oid:0x11008000000020|SAI_HA_SCOPE_ATTR_DASH_HA_ROLE=SAI_DASH_HA_ROLE_ACTIVE

|q|attribute_capability|SAI_OBJECT_TYPE_SWITCH:oid:0x21000000000000|OBJECT_TYPE=SAI_OBJECT_TYPE_ENI|ATTR_ID=SAI_ENI_ATTR_IS_HA_FLOW_OWNER
|Q|attribute_capability|SAI_STATUS_SUCCESS|OBJECT_TYPE=SAI_OBJECT_TYPE_ENI|ATTR_ID=SAI_ENI_ATTR_IS_HA_FLOW_OWNER|CREATE_IMP=false|SET_IMP=false|GET_IMP=false
|c|SAI_OBJECT_TYPE_ENI:oid:0x7008000000025|SAI_ENI_ATTR_VNET_ID=oid:0xe008000000022|SAI_ENI_ATTR_ADMIN_STATE=true|SAI_ENI_ATTR_VM_UNDERLAY_DIP=25.1.1.1|SAI_ENI_ATTR_VM_VNI=4321|SAI_ENI_ATTR_PL_UNDERLAY_SIP=3.2.1.0|SAI_ENI_ATTR_PL_SIP=::d107:64:ff71:0:0|SAI_ENI_ATTR_PL_SIP_MASK=::ffff:ffff:ffff:0:0|SAI_ENI_ATTR_HA_SCOPE_ID=oid:0x12008000000021

```


**Details if related**
